### PR TITLE
test: add baseline web app assertions

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,22 +1,15 @@
-import logo from './logo.svg';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+        <h1>LeetCode Coach</h1>
+        <p>Practice smarter with feedback-driven problem solving.</p>
+        <div>
+          <button type="button">Browse Problems</button>
+          <button type="button">View Dashboard</button>
+        </div>
       </header>
     </div>
   );

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app heading and tagline', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: /leetcode coach/i })).toBeInTheDocument();
+  expect(
+    screen.getByText(/practice smarter with feedback-driven problem solving/i)
+  ).toBeInTheDocument();
+});
+
+test('renders primary call-to-action buttons', () => {
+  render(<App />);
+  expect(screen.getByRole('button', { name: /browse problems/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /view dashboard/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- updates the web app landing content to project-specific copy\n- adds baseline assertions for heading, tagline, and CTA buttons

## Issues
- Closes #24
- Next issue: #25

## Unit tests
- web tests pass with coverage enabled