### PR TITLE
feat(review): submission handoff, re-review UI, api helpers, home cleanup

### DIFF
--- a/mobile/app/(tabs)/feedback.tsx
+++ b/mobile/app/(tabs)/feedback.tsx
@@ -1,109 +1,232 @@
 import { useLocalSearchParams } from 'expo-router';
-import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native';
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 
+import { ProblemCodeEditor } from '@/components/problem-code-editor';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import {
+  clearFeedbackCodeHandoff,
+  peekFeedbackCodeHandoff,
+} from '@/lib/feedback-handoff';
+import { API_BASE_URL, getAuthHeaders } from '@/lib/api';
 
-const API_BASE_URL =
-  process.env.EXPO_PUBLIC_API_BASE_URL ??
-  (Platform.OS === 'web' ? 'http://localhost:8080' : 'http://10.0.2.2:8080');
+type FeedbackDto = {
+  score: number | null;
+  feedbackText?: string | null;
+};
 
+const DEFAULT_LANGUAGE = 'python';
 
 export default function FeedbackScreen() {
-  const { submissionId } = useLocalSearchParams();
+  const rawId = useLocalSearchParams<{ submissionId: string | string[] }>().submissionId;
+  const submissionId = Array.isArray(rawId) ? rawId[0] : rawId;
 
-  const [feedback, setFeedback] = useState<any>(null);
+  const [code, setCode] = useState('');
+  const [feedback, setFeedback] = useState<FeedbackDto | null>(null);
+  const [submissionStatus, setSubmissionStatus] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [submitMessage, setSubmitMessage] = useState('');
 
-  // useEffect(() => {
-  //   async function fetchFeedback() {
-  //     try {
-  //       const res = await fetch(
-  //         `http://10.0.2.2:8080/submissions/${submissionId}/feedback`
-  //       );
+  useLayoutEffect(() => {
+    if (!submissionId) return;
+    const fromHandoff = peekFeedbackCodeHandoff(submissionId);
+    if (fromHandoff) {
+      setCode(fromHandoff);
+      setLoading(false);
+    }
+  }, [submissionId]);
 
-  //       const data = await res.json();
-
-        
-  //       setFeedback(data);
-  //     } catch (err) {
-  //       console.error(err);
-  //     } finally {
-  //       setLoading(false);
-  //     }
-  //   }
-
-  //   fetchFeedback();
-  // }, [submissionId]);
-  useEffect(() => {
-  async function fetchFeedback() {
-    try {
+  const fetchData = useCallback(
+    async (showPageLoader: boolean) => {
       if (!submissionId) return;
+      if (showPageLoader && peekFeedbackCodeHandoff(submissionId) === undefined) {
+        setLoading(true);
+      }
+      try {
+        const headers = await getAuthHeaders();
 
-      const res = await fetch(`${API_BASE_URL}/api/submissions/${submissionId}/feedback`);
+        const [subRes, fbRes] = await Promise.all([
+          fetch(`${API_BASE_URL}/api/submissions/${submissionId}`, { headers }),
+          fetch(`${API_BASE_URL}/api/submissions/${submissionId}/feedback`),
+        ]);
+
+        if (subRes.ok) {
+          const sub = await subRes.json();
+          setCode(typeof sub.code === 'string' ? sub.code : '');
+          clearFeedbackCodeHandoff(submissionId);
+          setSubmissionStatus(typeof sub.status === 'string' ? sub.status : null);
+        } else if (subRes.status === 401) {
+          setSubmitMessage((m) => m || 'Sign in required to edit this submission.');
+        }
+
+        if (fbRes.ok) {
+          const data = await fbRes.json();
+          setFeedback({
+            score: typeof data.score === 'number' ? data.score : null,
+            feedbackText: data.feedbackText ?? '',
+          });
+        }
+      } catch (e) {
+        console.error(e);
+        setSubmitMessage('Could not load submission or feedback.');
+      } finally {
+        if (showPageLoader) setLoading(false);
+      }
+    },
+    [submissionId],
+  );
+
+  useEffect(() => {
+    setSubmitMessage('');
+    void fetchData(true);
+  }, [submissionId, fetchData]);
+
+  async function handleSaveAndReview() {
+    if (!submissionId) return;
+
+    const trimmed = code.trim();
+    if (trimmed.length < 10) {
+      setSubmitMessage('Write a fuller solution before re-running review.');
+      return;
+    }
+
+    setSaving(true);
+    setSubmitMessage('Re-running review…');
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/submissions/${submissionId}`, {
+        method: 'PUT',
+        headers: await getAuthHeaders(),
+        body: JSON.stringify({
+          code: trimmed,
+          language: DEFAULT_LANGUAGE,
+        }),
+      });
 
       if (!res.ok) {
-        throw new Error(`Feedback request failed: ${res.status}`);
+        const t = await res.text();
+        setSubmitMessage(`Save failed (${res.status}): ${t || 'unknown error'}`);
+        return;
       }
 
-      const data = await res.json();
-      setFeedback(data);
-    } catch (err) {
-      console.error(err);
+      await fetchData(false);
+      setSubmitMessage('Review updated with your edited code.');
+    } catch (e) {
+      setSubmitMessage(e instanceof Error ? e.message : 'Request failed.');
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   }
 
-    fetchFeedback();
-  }, [submissionId]);
+  if (!submissionId) {
+    return (
+      <ThemedView style={styles.center}>
+        <ThemedText>Missing submission id.</ThemedText>
+      </ThemedView>
+    );
+  }
 
   if (loading) {
     return (
       <ThemedView style={styles.center}>
         <ActivityIndicator size="large" />
-        <ThemedText>Analyzing your code...</ThemedText>
-      </ThemedView>
-    );
-  }
-
-  if (!feedback) {
-    return (
-      <ThemedView style={styles.center}>
-        <ThemedText>No feedback available.</ThemedText>
+        <ThemedText>Loading your submission…</ThemedText>
       </ThemedView>
     );
   }
 
   return (
-    <ThemedView style={styles.container}>
-      <ThemedText type="title">AI Feedback</ThemedText>
+    <ThemedView style={styles.flex}>
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <ThemedText type="title">Review</ThemedText>
+        {submissionStatus ? (
+          <ThemedText style={styles.muted}>Status: {submissionStatus}</ThemedText>
+        ) : null}
 
-      <View style={styles.card}>
-        <ThemedText type="subtitle">Score</ThemedText>
-        <ThemedText>{feedback.score}/100</ThemedText>
-      </View>
+        <View style={styles.editorSection}>
+          <ThemedText type="subtitle">Your submission</ThemedText>
+          <ThemedText style={styles.hint}>
+            Continue from the code you shipped. Save to run another AI review after edits.
+          </ThemedText>
+          <ProblemCodeEditor
+            value={code}
+            onChange={setCode}
+            style={[
+              styles.editor,
+              Platform.OS === 'web' ? { minHeight: 260 } : { minHeight: 220 },
+            ]}
+          />
+          <Pressable
+            accessibilityRole="button"
+            disabled={saving}
+            onPress={() => void handleSaveAndReview()}
+            style={({ pressed }) => [
+              styles.saveBtn,
+              (pressed || saving) && styles.pressedBtn,
+              saving && styles.dimmedBtn,
+            ]}>
+            <ThemedText style={styles.saveBtnLabel}>{saving ? 'Reviewing…' : 'Save & re-run review'}</ThemedText>
+          </Pressable>
+          {submitMessage ? (
+            <ThemedText style={styles.message}>{submitMessage}</ThemedText>
+          ) : null}
+        </View>
 
-      <View style={styles.card}>
-        <ThemedText type="subtitle">Review</ThemedText>
-        <ThemedText>{feedback.feedbackText}</ThemedText>
-      </View>
+        <View style={styles.feedbackSection}>
+          <ThemedText type="subtitle">AI feedback</ThemedText>
+          {feedback ? (
+            <>
+              <View style={styles.card}>
+                <ThemedText type="defaultSemiBold">Score</ThemedText>
+                <ThemedText>{feedback.score ?? '—'}/100</ThemedText>
+              </View>
+
+              <View style={styles.card}>
+                <ThemedText type="defaultSemiBold">Review</ThemedText>
+                <ThemedText>{feedback.feedbackText ?? '—'}</ThemedText>
+              </View>
+            </>
+          ) : (
+            <ThemedText style={styles.muted}>No feedback available yet.</ThemedText>
+          )}
+        </View>
+      </ScrollView>
     </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
   container: {
-    flex: 1,
     padding: 20,
-    gap: 16,
+    paddingBottom: 40,
+    gap: 14,
+    maxWidth: 900,
+    alignSelf: 'center',
+    width: '100%',
   },
   center: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     gap: 10,
+  },
+  muted: {
+    opacity: 0.75,
+  },
+  hint: {
+    opacity: 0.85,
+    fontSize: 14,
+    lineHeight: 20,
   },
   card: {
     borderWidth: 1,
@@ -112,4 +235,39 @@ const styles = StyleSheet.create({
     padding: 16,
     gap: 8,
   },
+  editorSection: {
+    gap: 12,
+    marginTop: 4,
+  },
+  feedbackSection: {
+    gap: 12,
+    marginTop: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#3A3A3A',
+    paddingTop: 18,
+  },
+  editor: {
+    minHeight: 260,
+    borderWidth: 1,
+    borderColor: '#3A3A3A',
+    borderRadius: 12,
+    padding: Platform.OS === 'web' ? 0 : 12,
+    color: '#fff',
+    fontFamily: Platform.OS === 'web' ? undefined : 'monospace',
+    fontSize: 14,
+  },
+  saveBtn: {
+    alignSelf: 'flex-start',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#0a7ea4',
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    backgroundColor: 'rgba(10, 126, 164, 0.18)',
+    marginTop: 4,
+  },
+  pressedBtn: { opacity: 0.82 },
+  dimmedBtn: { opacity: 0.55 },
+  saveBtnLabel: { color: '#7fd7f7', fontWeight: '700' },
+  message: { fontSize: 14, opacity: 0.9 },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,20 +1,12 @@
 import { useState } from 'react';
 import { Pressable, ScrollView, StyleSheet } from 'react-native';
-import { useRouter } from 'expo-router';
-import { supabase } from '@/lib/supabase';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 
 export default function HomeScreen() {
-  const router = useRouter();
   const [backendStatus, setBackendStatus] = useState('Not checked');
   const [isCheckingBackend, setIsCheckingBackend] = useState(false);
-
-  async function handleLogout() {
-    await supabase.auth.signOut();
-    router.replace('/login');
-  }
 
   async function checkBackendStatus() {
     setIsCheckingBackend(true);
@@ -72,20 +64,6 @@ export default function HomeScreen() {
             </ThemedText>
           </Pressable>
         </ThemedView>
-
-        <ThemedView style={styles.section}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={handleLogout}
-            style={({ pressed }) => [
-              styles.logoutButton,
-              pressed && styles.buttonPressed,
-            ]}>
-            <ThemedText type="defaultSemiBold" style={styles.logoutText}>
-              Logout
-            </ThemedText>
-          </Pressable>
-        </ThemedView>
       </ScrollView>
     </ThemedView>
   );
@@ -120,18 +98,5 @@ const styles = StyleSheet.create({
   },
   buttonDisabled: {
     opacity: 0.6,
-  },
-  logoutButton: {
-    marginTop: 8,
-    borderRadius: 10,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    borderColor: '#d32f2f',
-    alignItems: 'center',
-    backgroundColor: 'rgba(211, 47, 47, 0.1)',
-  },
-  logoutText: {
-    color: '#d32f2f',
   },
 });

--- a/mobile/app/problems/[id].tsx
+++ b/mobile/app/problems/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import {
-  Platform,
+  Alert,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -13,10 +13,9 @@ import { formatElapsedTime, getProblemById } from '@/utils/problemHelpers';
 import { MOCK_PROBLEMS } from '@/data/mockProblems';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { stashFeedbackCodeForReview } from '@/lib/feedback-handoff';
+import { API_BASE_URL } from '@/lib/api';
 
-const API_BASE_URL =
-  process.env.EXPO_PUBLIC_API_BASE_URL ??
-  (Platform.OS === 'web' ? 'http://localhost:8080' : 'http://10.0.2.2:8080');
 const DEFAULT_LANGUAGE = 'python';
 
 // Temporary demo user ID for local/testing submissions.
@@ -79,72 +78,31 @@ export default function ProblemDetailScreen() {
   }
 
   async function handleSubmit() {
+    if (!problem) {
+      Alert.alert('Error', 'Problem not found.');
+      return;
+    }
+
     if (!code || code.trim().length < 10) {
       Alert.alert('Incomplete', 'Please write a more substantial solution before submitting.');
       return;
     }
 
     setIsSubmitting(true);
+    setSubmitStatus(`Submitting to ${API_BASE_URL}/api/submissions…`);
+
+    const trimmed = code.trim();
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/submissions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          problemId: Number(id) || 1, // Fallback for testing
-          code: code,
-          userId: 1, // Hardcoded user for now
-          status: "Submitted",
-          timeTaken: secondsElapsed,
-        }),
-        buttonDisabled: {
-    opacity: 0.5,
-  },
-});
+      const submissionPayload = {
+        problemId: problem.dbId,
+        code: trimmed,
+        language: DEFAULT_LANGUAGE,
+        userId: DEMO_USER_ID,
+        status: 'Submitted',
+        timeTaken: secondsElapsed,
+      };
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Submission failed: ${response.status} ${errorText}`);
-      }
-
-      const submission = await response.json();
-
-      Alert.alert('Success', 'Your solution has been submitted and analyzed!', [
-        {
-          text: 'View Feedback',
-          onPress: () => {
-            router.push({
-              pathname: "/(tabs)/feedback",
-              params: { submissionId: String(submission.id) },
-              buttonDisabled: {
-    opacity: 0.5,
-  },
-});
-          }
-        }
-      ]);
-    } catch (error: any) {
-      console.error(error);
-      Alert.alert("Submission Error", "Could not connect to the backend. Is your server running?");
-    } finally {
-      setIsSubmitting(false);
-    }
-    if (!problem) {
-      Alert.alert('Error', 'Problem not found.');
-      return;
-    }
-
-    const submissionPayload = {
-      problemId: problem.dbId,
-      code,
-      userId: DEMO_USER_ID,
-      status: 'Submitted',
-      timeTaken: secondsElapsed,
-    };
-
-    try {
       const response = await fetch(`${API_BASE_URL}/api/submissions`, {
         method: 'POST',
         headers: {
@@ -155,7 +113,7 @@ export default function ProblemDetailScreen() {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Submission failed: ${response.status} ${errorText}`);
+        throw new Error(`${response.status} ${errorText}`);
       }
 
       const submission = await response.json();
@@ -164,9 +122,12 @@ export default function ProblemDetailScreen() {
       setSubmitStatus(`Review complete. Gemini marked this submission as ${reviewStatus}.`);
       setTestOutput(`Submitted successfully. Status: ${reviewStatus}.`);
 
+      const sid = String(submission.id);
+      stashFeedbackCodeForReview(sid, trimmed);
+
       router.push({
         pathname: '/(tabs)/feedback',
-        params: { submissionId: String(submission.id) },
+        params: { submissionId: sid },
       });
     } catch (error) {
       console.error(error);
@@ -174,6 +135,7 @@ export default function ProblemDetailScreen() {
       setSubmitStatus(
         `Submission failed. Make sure the backend is running at ${API_BASE_URL}. ${message}`
       );
+      Alert.alert('Submission Error', `Could not complete submission.\n${message}`);
     } finally {
       setIsSubmitting(false);
     }

--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -1,6 +1,25 @@
+import { Platform } from 'react-native';
+
 import { supabase } from './supabase';
 
-const BACKEND_URL = 'http://localhost:8080';
+export const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ??
+  (Platform.OS === 'web' ? 'http://localhost:8080' : 'http://10.0.2.2:8080');
+
+/** JSON headers plus Supabase Bearer when logged in (needed for guarded submission APIs). */
+export async function getAuthHeaders(): Promise<HeadersInit & Record<string, string>> {
+  const { data: { session } } = await supabase.auth.getSession();
+  const headers: HeadersInit & Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const token = session?.access_token;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+const BACKEND_URL = API_BASE_URL;
 
 export async function callBackendEndpoint(endpoint: string, method: string = 'GET', body?: any) {
   const { data: { session } } = await supabase.auth.getSession();

--- a/mobile/lib/feedback-handoff.ts
+++ b/mobile/lib/feedback-handoff.ts
@@ -1,0 +1,18 @@
+/**
+ * Carries the just-submitted source from the problem screen into the feedback route
+ * so the editor can show it immediately (same JS session). Server fetch still
+ * reconciles as source of truth; clear after a successful load.
+ */
+const handoffBySubmissionId = new Map<string, string>();
+
+export function stashFeedbackCodeForReview(submissionId: string, code: string): void {
+  handoffBySubmissionId.set(submissionId, code);
+}
+
+export function peekFeedbackCodeHandoff(submissionId: string): string | undefined {
+  return handoffBySubmissionId.get(submissionId);
+}
+
+export function clearFeedbackCodeHandoff(submissionId: string): void {
+  handoffBySubmissionId.delete(submissionId);
+}


### PR DESCRIPTION
## Summary
Submission handoff onto the feedback tab, full review/edit flow backed by PUT, shared API helpers, and home tab logout removed from body.

Closes https://github.com/CST438-Project3-Group3-LeetCodeReviewer/frontend/issues/39

## Changes
See issue #39 for the detailed breakdown (backend tracked in a sibling PR).

**Pairs with backend PR:** open a PR titled `feature/submission-edit-rerun-review` in the backend repo — merge backend first.

## QA
Submit from problem → feedback shows code immediately; Save & re-run review updates Gemini output; logged-in GET loads code without handoff.

Made with [Cursor](https://cursor.com)